### PR TITLE
Cache parsed signing key for performance

### DIFF
--- a/manta/local_test.go
+++ b/manta/local_test.go
@@ -55,7 +55,8 @@ func (s *LocalTests) SetUpSuite(c *gc.C) {
 	s.Server.Config.Handler = s.Mux
 
 	// Set up a Joyent Manta service.
-	authentication := auth.Auth{User: "localtest", PrivateKey: string(privateKey), Algorithm: "rsa-sha256"}
+	authentication, err := auth.NewAuth("localtest", string(privateKey), "rsa-sha256")
+	c.Assert(err, gc.IsNil)
 
 	s.creds = &auth.Credentials{
 		UserAuthentication: authentication,


### PR DESCRIPTION
Update to use the new Auth constructor which caches the signing key
