### PR TITLE
Correctly assert and dereference in GetObject to return valid data.

### DIFF
--- a/manta/manta.go
+++ b/manta/manta.go
@@ -191,8 +191,8 @@ func (c *Client) GetObject(path, objectName string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Newf(err, "failed to get object %s/%s", path, objectName)
 	}
-	res, _ := respData.RespValue.([]byte)
-	return res, nil
+	res, _ := respData.RespValue.(*[]byte)
+	return *res, nil
 }
 
 // Deletes the specified object from the specified location.

--- a/manta/manta.go
+++ b/manta/manta.go
@@ -191,7 +191,10 @@ func (c *Client) GetObject(path, objectName string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Newf(err, "failed to get object %s/%s", path, objectName)
 	}
-	res, _ := respData.RespValue.(*[]byte)
+	res, ok := respData.RespValue.(*[]byte)
+	if !ok {
+		return nil, errors.Newf(err, "failed to assert downloaded data as type *[]byte for object %s/%s", path, objectName)
+	}
 	return *res, nil
 }
 


### PR DESCRIPTION
Previously, the value of `respData.RespValue` was asserted to be of type
[]byte, when the type was actually *[]byte. The assertion failed, but the
"failed assertion" boolean was discarded with _ and never
checked for an invalid assertion (which it was). This did not cause a
compiler error because the explicit type of `respData.RespValue` was
interface{}. The method GetObject would return an empty []byte when a valid object
was requested, because the assertion was failing and therefore the `res`
variable was empty.

This commit changes the assertion to type *[]byte,
which is successful and then dereferences it for the return for type []byte.
This results in the object's data being correctly returned from
the Client.GetObject method.

Before this change, test LocalTests.TestGetObject from local_test.go:157 failed on check:
```
165: c.Assert(obj, gc.NotNil)
     value []uint8 = []byte(nil)
```
It now passes.