### PR TITLE
Update localservices to use httprouter from test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ _cgo_gotypes.go
 _cgo_export.*
 
 _testmain.go
+*.test
 
 *.exe
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ cd ${GOPATH}/src/github.com/joyent/gomanta
 go test ./...
 ```
 
+The `manta` package tests can also be run against live Manta. If you want to run this package, you can pass the `-live` flag and the `-key.name` flag (the latter is optional and defaults to `~/.ssh/id_rsa`) as shown below. Note that you can only run the `manta` package tests this way and running the rest of the test suite with these flags will result in a test runner error ("flag provided but not defined").
+
+```
+cd ${GOPATH}/src/github.com/joyent/gomanta
+go test ./manta -live -key.name=~/.ssh/my_key
+```
+
+
 ### Build the Library
 
 ```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ gomanta
 
 The gomanta package enables Go programs to interact with the Joyent Manta service.
 
+[![wercker status](https://app.wercker.com/status/e315959b9089bba1da9aff10d36e5b4c/s/master "wercker status")](https://app.wercker.com/project/byKey/e315959b9089bba1da9aff10d36e5b4c)
+
 ## Installation
 
 Use `go-get` to install gomanta

--- a/localservices/localservice.go
+++ b/localservices/localservice.go
@@ -18,14 +18,14 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"net/http"
 
 	"github.com/joyent/gomanta/localservices/hook"
+	"github.com/julienschmidt/httprouter"
 )
 
 // An HttpService provides the HTTP API for a service double.
 type HttpService interface {
-	SetupHTTP(mux *http.ServeMux)
+	SetupHTTP(mux *httprouter.Router)
 }
 
 // A ServiceInstance is an Joyent Cloud service, one of manta or cloudapi.

--- a/localservices/manta/service_http_test.go
+++ b/localservices/manta/service_http_test.go
@@ -17,14 +17,13 @@ package manta_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
 
 	gc "launchpad.net/gocheck"
-
-	"fmt"
 
 	"github.com/joyent/gocommon/testing"
 	lm "github.com/joyent/gomanta/localservices/manta"

--- a/manta/local_test.go
+++ b/manta/local_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/julienschmidt/httprouter"
 	gc "launchpad.net/gocheck"
 
 	"github.com/joyent/gocommon/client"
@@ -47,7 +48,7 @@ func registerLocalTests(keyName string) {
 type LocalTests struct {
 	LiveTests
 	Server     *httptest.Server
-	Mux        *http.ServeMux
+	Mux        *httprouter.Router
 	oldHandler http.Handler
 	manta      *localmanta.Manta
 }
@@ -56,7 +57,7 @@ func (s *LocalTests) SetUpSuite(c *gc.C) {
 	// Set up the HTTP server.
 	s.Server = httptest.NewServer(nil)
 	s.oldHandler = s.Server.Config.Handler
-	s.Mux = http.NewServeMux()
+	s.Mux = httprouter.New()
 	s.Server.Config.Handler = s.Mux
 
 	// Set up a Joyent Manta service.
@@ -143,7 +144,6 @@ func (s *LocalTests) TestListDirectory(c *gc.C) {
 
 func (s *LocalTests) TestDeleteDirectory(c *gc.C) {
 	s.createDirectory(c, "test")
-
 	s.deleteDirectory(c, "test")
 }
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,35 @@
+box: golang
+
+build:
+  steps:
+    # Sets the go workspace and places you package
+    # at the right place in the workspace tree
+    - setup-go-workspace:
+        package-dir: github.com/joyent/gomanta
+
+    # Gets the dependencies
+    - script:
+        name: go get
+        code: |
+          go get -v -t ./...
+
+    # Build the project
+    - script:
+        name: go build
+        code: |
+          go build ./...
+
+    - script:
+        name: make a new key for testing
+        code: |
+          ssh-keygen -b 2048 \
+                     -C "Testing Key" \
+                     -f /root/.ssh/id_rsa \
+                     -t rsa \
+                     -P ""
+
+    # Test the project
+    - script:
+        name: go test
+        code: |
+          go test ./...


### PR DESCRIPTION
For https://github.com/joyent/gomanta/issues/7

This updates our test suite to be compatible with the `httprouter` library that was added to `gocommon`. This results in a much more manual and explicit test suite setup because of some of the funky limitations in that library (which is really designed for performance, not testing... but to back that library our now would have ripple effects to our Terraform providers which I'd rather not take on now).

cc @misterbisson @chorrell 

Test runs:

```
$ go test ./...
ok      github.com/joyent/gomanta       0.007s
?       github.com/joyent/gomanta/localservices [no test files]
ok      github.com/joyent/gomanta/localservices/hook    0.009s
ok      github.com/joyent/gomanta/localservices/manta   0.053s
ok      github.com/joyent/gomanta/manta 0.265s

$ go test ./manta -live
ok      github.com/joyent/gomanta/manta 8.790s
```